### PR TITLE
Add split premiere non-elim handling and S13 stat presets

### DIFF
--- a/app/(root)/buildcast/page.tsx
+++ b/app/(root)/buildcast/page.tsx
@@ -468,7 +468,7 @@ const Page = () => {
                         ...prev,
                         {
                           ...queen,
-                          stats: generateRandomStats(),
+                          stats: queen.stats ?? generateRandomStats(),
                         },
                       ];
                     });

--- a/components/CardList.tsx
+++ b/components/CardList.tsx
@@ -17,6 +17,7 @@ type Queen = {
     highs: number;
     lows: number;
     bottoms: number;
+    top2s: number;
     isEliminated: boolean;
     scores: { episodeNumber: string | number; score: number }[];
     placements: any;

--- a/components/EpisodeList.tsx
+++ b/components/EpisodeList.tsx
@@ -60,7 +60,11 @@ const EpisodeList = ({
           return placement?.placement === "safe";
         });
 
-        const isFinale = ep.type?.toLowerCase().includes("finale");
+        const typeTokens = ep.type
+          ? ep.type.toLowerCase().split(",").map((t: string) => t.trim())
+          : [];
+        const isFinale = typeTokens.includes("finale");
+        const isSplitPremiereNonElim = typeTokens.includes("non elim") || typeTokens.includes("nonelim");
 
         return (
           <div
@@ -117,6 +121,14 @@ const EpisodeList = ({
                   >
                     Winner
                   </button>
+                  {isSplitPremiereNonElim && (
+                    <button
+                      className="px-3 py-1 text-xs rounded-full bg-purple-200 hover:bg-purple-300 transition"
+                      onClick={(e) => handleEventClick(e, ep.episodeNumber, "top2", ep.nonElimination || "")}
+                    >
+                      Top 2
+                    </button>
+                  )}
                   <button
                     className="px-3 py-1 text-xs rounded-full bg-red-200 hover:bg-red-300 transition"
                     onClick={(e) => handleEventClick(e, ep.episodeNumber, "bottom", ep.nonElimination || "")}

--- a/components/EpisodeMessage.tsx
+++ b/components/EpisodeMessage.tsx
@@ -4,6 +4,7 @@ const EVENT_LBLS: Record<string, string> = {
     announceSafe: "Safe Queens",
     winner: "Winner",
     high: "High Queens",
+    top2: "Top 2 Queens",
     bottom: "Bottom Queens",
     bottom2: "Bottom 2",
     eliminated: "Eliminated Queen",

--- a/components/QueenCard.tsx
+++ b/components/QueenCard.tsx
@@ -18,6 +18,7 @@ type QueenStats = {
   Dance: number;
   Comedy: number;
   Design: number;
+  Runway: number;
   Singing: number;
 };
 
@@ -33,6 +34,7 @@ type Queen = {
   highs?: number;
   lows?: number;
   bottoms?: number;
+  top2s?: number;
   isEliminated?: boolean;
   stats?: QueenStats;
 };
@@ -131,6 +133,7 @@ const QueenCard = ({ q,
 
         <div className="grid grid-cols-2 gap-2 text-sm text-gray-700 text-center">
           {q.wins != null && (<p>Wins: {q.wins}</p>)}
+          {q.top2s != null && (<p>Top 2: {q.top2s}</p>)}
           {q.highs != null && (<p>Highs: {q.highs}</p>)}
           {q.lows != null && (<p>Lows: {q.lows}</p>)}
           {q.bottoms != null && (<p>Bottoms: {q.bottoms}</p>)}

--- a/components/SeasonTrackRecordTable.tsx
+++ b/components/SeasonTrackRecordTable.tsx
@@ -21,6 +21,7 @@ type Queen = {
   placements: { episodeNumber: number | string; placement: string }[];
   url: string;
   wins: number;
+  top2s?: number;
   highs: number;
   lows: number;
   bottoms: number;
@@ -101,6 +102,8 @@ const SeasonTrackRecordTable = ({
         return "WIN";
       case "high":
         return "HIGH";
+      case "top2":
+        return "TOP2";
       case "safe":
         return "SAFE";
       case "low":
@@ -162,6 +165,7 @@ const SeasonTrackRecordTable = ({
   });
 
   const maxWins = Math.max(...queens.map((q) => q.wins));
+  const maxTop2s = Math.max(...queens.map((q) => q.top2s ?? 0));
   const maxHighs = Math.max(...queens.map((q) => q.highs));
   const maxLows = Math.max(...queens.map((q) => q.lows));
   const maxBottoms = Math.max(...queens.map((q) => q.bottoms));
@@ -199,6 +203,7 @@ const SeasonTrackRecordTable = ({
                 </TableHead>
               ))}
               <TableHead className="text-center">Wins</TableHead>
+              <TableHead className="text-center">Top 2</TableHead>
               <TableHead className="text-center">Highs</TableHead>
               <TableHead className="text-center">Lows</TableHead>
               <TableHead className="text-center">Bottoms</TableHead>
@@ -248,6 +253,7 @@ const SeasonTrackRecordTable = ({
                           ${placement === "HIGH" ? "bg-sky-300 text-black-200" : ""}
                           ${placement === "WIN" ? "bg-blue-400 text-black-200" : ""}
                           ${placement === "LOW" ? "bg-pink-200 text-black-200" : ""}
+                          ${placement === "TOP2" ? "bg-purple-200 text-black-200" : ""}
                           ${placement === "BTM2" ? "bg-red-300 text-black-200" : ""}
                           ${placement === "WINNER" ? "sparkle-gold" : ""}
                           ${placement === "RUNNER-UP" ? "bg-green-200 text-black font-medium" : ""}
@@ -265,6 +271,19 @@ const SeasonTrackRecordTable = ({
                   >
                     {q.wins}{" "}
                     {q.wins === maxWins && <FontAwesomeIcon icon={faCrown} />}
+                  </TableCell>
+
+                  <TableCell
+                    className={`text-center ${
+                      (q.top2s ?? 0) === maxTop2s && maxTop2s > 0
+                        ? "ml-1 bg-yellow-200 font-bold"
+                        : ""
+                    }`}
+                  >
+                    {q.top2s ?? 0}{" "}
+                    {(q.top2s ?? 0) === maxTop2s && maxTop2s > 0 && (
+                      <FontAwesomeIcon icon={faCrown} />
+                    )}
                   </TableCell>
 
                   <TableCell

--- a/constants/queenData.ts
+++ b/constants/queenData.ts
@@ -1389,91 +1389,195 @@ export const queens = [
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/3/36/DenaliS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902181626',
     seasons: '13,AS10',
     name: "Denali",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 70,
+      Dance: 95,
+      Comedy: 65,
+      Design: 60,
+      Runway: 80,
+      Singing: 55,
+    }
   },
   {
     id: 'VDzrunSAdFpQsPiB22dI',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/0/0b/ElliottWith2T%27sS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902181745',
     seasons: '13',
     name: "Elliott With 2 Ts",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 55,
+      Dance: 85,
+      Comedy: 50,
+      Design: 45,
+      Runway: 70,
+      Singing: 60,
+    }
   },
   {
     id: '4fCfJozI92fuhdLs2UDb',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/a/a7/JoeyJayS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182023',
     seasons: '13',
     name: "Joey Jay",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 50,
+      Dance: 70,
+      Comedy: 55,
+      Design: 40,
+      Runway: 60,
+      Singing: 65,
+    }
   },
   {
     id: 'auLfJozI92gMgdLs2UDb',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/b/bd/GottmikS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902181947',
     seasons: '13,AS9',
     name: "Gottmik",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 80,
+      Dance: 60,
+      Comedy: 85,
+      Design: 90,
+      Runway: 95,
+      Singing: 50,
+    }
   },
   {
     id: '7iFdqehdbL0JjOcwdWBy',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/e/e5/KahmoraHallS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182128',
     seasons: '13',
     name: "Kahmora Hall",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 45,
+      Dance: 40,
+      Comedy: 35,
+      Design: 70,
+      Runway: 90,
+      Singing: 40,
+    }
   },
   {
     id: 'rhOn7RHexb27Hx02pd4u',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/6/63/KandyMuseS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182209',
     seasons: '13,AS8',
     name: "Kandy Muse",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 75,
+      Dance: 65,
+      Comedy: 80,
+      Design: 55,
+      Runway: 70,
+      Singing: 50,
+    }
   },
   {
     id: 'G5HVACaVRzQcVzDRbzlY',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/e/e0/LaLaRiS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182255',
     seasons: '13,AS8',
     name: "Lala Ri",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 65,
+      Dance: 80,
+      Comedy: 60,
+      Design: 45,
+      Runway: 65,
+      Singing: 55,
+    }
   },
   {
     id: 'G4fVACaVRzQcVzDRbzlY',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/4/4f/OliviaLuxS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182353',
     seasons: '13,AS10',
     name: "Olivia Luxx",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 70,
+      Dance: 75,
+      Comedy: 68,
+      Design: 62,
+      Runway: 72,
+      Singing: 85,
+    }
   },
   {
     id: '5jQ3YcBfH0fYLJZupGQL',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/7/74/Ros%C3%A9S13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182428',
     seasons: '13',
     name: "Rosé",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 88,
+      Dance: 80,
+      Comedy: 82,
+      Design: 70,
+      Runway: 78,
+      Singing: 92,
+    }
   },
   {
     id: '5j4f5cBfH0fYLJZupGQL',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/7/7d/SymoneS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20211216235826',
     seasons: '13',
     name: "Symone",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 85,
+      Dance: 70,
+      Comedy: 90,
+      Design: 65,
+      Runway: 88,
+      Singing: 60,
+    }
   },
   {
     id: 'tKLXASuGPeb05fVfW55Y',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/3/35/TamishaImanS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182545',
     seasons: '13',
     name: "Tamisha Iman",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 72,
+      Dance: 68,
+      Comedy: 62,
+      Design: 58,
+      Runway: 75,
+      Singing: 65,
+    }
   },
   {
     id: 'E0PWgyI0x3sQ4ucHxhe4',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/4/44/TinaBurnerS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182624',
     seasons: '13,AS10',
     name: "Tina Burner",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 78,
+      Dance: 60,
+      Comedy: 85,
+      Design: 55,
+      Runway: 60,
+      Singing: 70,
+    }
   },
   {
     id: 'jpacB8Bl9pJuxad0nSxA',
     url: 'https://static.wikia.nocookie.net/logosrupaulsdragrace/images/d/dc/UticaQueenS13CastMug.jpg/revision/latest/scale-to-width-down/105?cb=20210902182704',
     seasons: '13',
     name: "Utica Queen",
-    franchise: 'US'
+    franchise: 'US',
+    stats: {
+      Acting: 65,
+      Dance: 70,
+      Comedy: 72,
+      Design: 90,
+      Runway: 85,
+      Singing: 58,
+    }
   },
   {
     id: 'ZsPFngAr2xqFXDayn1Vb',


### PR DESCRIPTION
## Summary
- add a dedicated non-elim split premiere flow that awards Top 2 placements without eliminations
- surface the new Top 2 placement in episode views, track record tables, and queen cards
- seed Season 13 queens with predetermined stats and use stored stats instead of rerolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2bec3063483329cf3b0a73159f16e